### PR TITLE
Allows the user to resize the window by a child element

### DIFF
--- a/AppBarExample/MainWindow.xaml
+++ b/AppBarExample/MainWindow.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="MainWindow" Height="350" Width="525">
-    <Grid>
+    <Grid x:Name="grid">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*"/>
             <ColumnDefinition Width="Auto"/>

--- a/AppBarExample/MainWindow.xaml.cs
+++ b/AppBarExample/MainWindow.xaml.cs
@@ -30,14 +30,14 @@ namespace AppBarExample
         {
             Normal.IsEnabled = false;
             AppBar.IsEnabled = true;
-            AppBarFunctions.SetAppBar(this, ABEdge.None);
+            AppBarFunctions.SetAppBar(this, ScreenEdge.None);
         }
 
         private void AppBar_OnClick(object sender, RoutedEventArgs e)
         {
             AppBar.IsEnabled = false;
             Normal.IsEnabled = true;
-            AppBarFunctions.SetAppBar(this, ABEdge.Left);
+            AppBarFunctions.SetAppBar(this, ScreenEdge.Left, grid);
         }
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -7,25 +7,27 @@ As seen in this StackOverflow question:
 
 [How do you do AppBar docking (to screen edge, like WinAmp) in WPF?](http://stackoverflow.com/q/75785/12643)
 
-
 What is it?
 ----------
 A helper for turning a WPF window into an "AppBar" like the windows taskbar.  
 I hope you're not writing any applications that need to do this, but if you 
 are, hopefully this library will help.
 
-
 How do I use it?
 ----------------
 To use, just call this code from anywhere within a normal wpf window (say a button click or the initialize). Note that you can not call this until AFTER the window is initialized, if the HWND hasn't been created yet (like in the constructor), an error will occur.
 
-
 ```C#
 //Make the window an appbar:
-AppBarFunctions.SetAppBar( this, ABEdge.Right );
-  
+AppBarFunctions.SetAppBar(this, ScreenEdge.Right);
+
+// If you want to resize the window by its content:
+AppBarFunctions.SetAppBar(this, ScreenEdge.Right, grid);
+AppBarFunctions.SetAppBar(this, ScreenEdge.Right, wrapPanel);
+// etc...
+
 //Restore the window to a normal window:
-AppBarFunctions.SetAppBar( this, ABEdge.None );
+AppBarFunctions.SetAppBar(this, ScreenEdge.None);
 ```
 
 I found a bug!
@@ -37,8 +39,6 @@ Thanks!
 
 That sounds okay... but licensing?
 ----------------------------------
-
-No warantee of any kind implied.
+No warranty of any kind implied.
 
 Creative Commons CC0 (https://creativecommons.org/publicdomain/zero/1.0/)
-

--- a/WpfAppBar/Interop.cs
+++ b/WpfAppBar/Interop.cs
@@ -1,13 +1,10 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace WpfAppBar
-{
-    class Interop
-    {
+namespace WpfAppBar {
+    class Interop {
         [StructLayout(LayoutKind.Sequential)]
-        internal struct RECT
-        {
+        internal struct RECT {
             public int left;
             public int top;
             public int right;
@@ -15,8 +12,7 @@ namespace WpfAppBar
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal struct APPBARDATA
-        {
+        internal struct APPBARDATA {
             public int cbSize;
             public IntPtr hWnd;
             public int uCallbackMessage;
@@ -24,10 +20,9 @@ namespace WpfAppBar
             public RECT rc;
             public IntPtr lParam;
         }
-        
+
         [System.Flags]
-        internal enum DWMWINDOWATTRIBUTE
-        {
+        internal enum DWMWINDOWATTRIBUTE {
             DWMA_NCRENDERING_ENABLED = 1,
             DWMA_NCRENDERING_POLICY,
             DWMA_TRANSITIONS_FORCEDISABLED,
@@ -44,16 +39,14 @@ namespace WpfAppBar
         }
 
         [System.Flags]
-        internal enum DWMNCRenderingPolicy
-        {
+        internal enum DWMNCRenderingPolicy {
             UseWindowStyle,
             Disabled,
             Enabled,
             Last
         }
 
-        internal enum ABMsg : int
-        {
+        internal enum ABMsg : int {
             ABM_NEW = 0,
             ABM_REMOVE,
             ABM_QUERYPOS,
@@ -66,8 +59,7 @@ namespace WpfAppBar
             ABM_WINDOWPOSCHANGED,
             ABM_SETSTATE
         }
-        internal enum ABNotify : int
-        {
+        internal enum ABNotify : int {
             ABN_STATECHANGE = 0,
             ABN_POSCHANGED,
             ABN_FULLSCREENAPP,
@@ -79,7 +71,7 @@ namespace WpfAppBar
 
         [DllImport("User32.dll", CharSet = CharSet.Auto)]
         internal static extern int RegisterWindowMessage(string msg);
-        
+
         [DllImport("dwmapi.dll")]
         internal static extern int DwmSetWindowAttribute(IntPtr hWnd, int attr, ref int attrValue, int attrSize);
     }


### PR DESCRIPTION
I was making a program that required this library and found that the window didn't resize correctly. The content of the window was 25 pixels high, like I wanted, but the window itself was 54 pixels high. To correct this, I added the ability for the user to resize the window by a specified child FrameworkElement.