### PR TITLE
Fixed System.ArgumentException when docking to bottom of screen

### DIFF
--- a/WpfAppBar/AppBarFunctions.cs
+++ b/WpfAppBar/AppBarFunctions.cs
@@ -174,7 +174,7 @@ namespace WpfAppBar
             // Even if the documentation says SystemParameters.PrimaryScreen{Width, Height} return values in 
             // "pixels", they return wpf units instead.
             var screenSizeInPixels =
-                toPixel.Transform(new Vector(SystemParameters.PrimaryScreenWidth, SystemParameters.PrimaryScreenHeight));
+                toPixel.Transform(new Vector(SystemParameters.WorkArea.Width, SystemParameters.WorkArea.Height));
 
             if (barData.uEdge == (int)ABEdge.Left || barData.uEdge == (int)ABEdge.Right)
             {


### PR DESCRIPTION
Sorry for the second pull request, but I was browsing through your issues and noticed someone said they had a problem with docking to the bottom. I tried it myself and got a System.ArgumentException error saying that my width/height or top/left values were negative. To fix this, I replaced PrimaryScreenWidth and PrimaryScreenHeight with WorkArea.Width and WorkArea.Height to get the work area of the screen (screen size minus the taskbar and other appbar applications).

I sort of messed up your assembly versions, though.. I have no idea what version the software is now.