### PR TITLE
Bug Fix. When you drag the window to the seconds screen, if you snap …

### DIFF
--- a/WpfAppBar/AppBarFunctions.cs
+++ b/WpfAppBar/AppBarFunctions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Threading;
 
@@ -238,7 +239,9 @@ namespace WpfAppBar
 
         private static Rect GetActualWorkArea(RegisterInfo info)
         {
-            var wa = SystemParameters.WorkArea;
+            var cwa = Screen.FromHandle(new WindowInteropHelper(info.Window).Handle).WorkingArea;
+            var wa = new Rect(new Point(cwa.Left, cwa.Top), new Point(cwa.Right, cwa.Bottom));
+
             if (info.DockedSize != null)
             {
                 wa.Union(info.DockedSize.Value);

--- a/WpfAppBar/WpfAppBar.csproj
+++ b/WpfAppBar/WpfAppBar.csproj
@@ -35,6 +35,8 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>


### PR DESCRIPTION
When you drag the window to the seconds screen, if you snap it, it used to snap to the primary screen instead of current one.
