### PR TITLE
Add support for multiple monitors, without adding dependencies

### DIFF
--- a/WpfAppBar/AppBarFunctions.cs
+++ b/WpfAppBar/AppBarFunctions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Threading;
 
@@ -243,7 +244,9 @@ namespace WpfAppBar
 
         private static Rect GetActualWorkArea(RegisterInfo info)
         {
-            var wa = SystemParameters.WorkArea;
+            var cwa = Screen.FromHandle(new WindowInteropHelper(info.Window).Handle).WorkingArea;
+            var wa = new Rect(new Point(cwa.Left, cwa.Top), new Point(cwa.Right, cwa.Bottom));
+
             if (info.DockedSize != null)
             {
                 wa.Union(info.DockedSize.Value);

--- a/WpfAppBar/AppBarFunctions.cs
+++ b/WpfAppBar/AppBarFunctions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Windows;
-using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Threading;
 
@@ -244,14 +243,23 @@ namespace WpfAppBar
 
         private static Rect GetActualWorkArea(RegisterInfo info)
         {
-            var cwa = Screen.FromHandle(new WindowInteropHelper(info.Window).Handle).WorkingArea;
-            var wa = new Rect(new Point(cwa.Left, cwa.Top), new Point(cwa.Right, cwa.Bottom));
+            var hWnd = new WindowInteropHelper(info.Window).Handle;
+            var cwa = GetMonitorWorkArea(Interop.MonitorFromWindow(hWnd, Interop.MonitorDefaultTo.MONITOR_DEFAULTTONEAREST));
+            var wa = new Rect(new Point(cwa.left, cwa.top), new Point(cwa.right, cwa.bottom));
 
             if (info.DockedSize != null)
             {
                 wa.Union(info.DockedSize.Value);
             }
             return wa;
+        }
+
+        private static Interop.RECT GetMonitorWorkArea(IntPtr hMonitor)
+        {
+            var monitorInfo = new Interop.MONITORINFO();
+            monitorInfo.cbSize = Marshal.SizeOf(monitorInfo);
+            Interop.GetMonitorInfo(hMonitor, ref monitorInfo);
+            return monitorInfo.rcWork;
         }
     }
 }

--- a/WpfAppBar/Interop.cs
+++ b/WpfAppBar/Interop.cs
@@ -74,6 +74,22 @@ namespace WpfAppBar
             ABN_WINDOWARRANGE
         }
 
+        internal enum MonitorDefaultTo
+        {
+            MONITOR_DEFAULTTONULL,
+            MONITOR_DEFAULTTOPRIMARY,
+            MONITOR_DEFAULTTONEAREST
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct MONITORINFO
+        {
+            public int cbSize;
+            public RECT rcMonitor;
+            public RECT rcWork;
+            public uint dwFlags;
+        }
+
         [DllImport("SHELL32", CallingConvention = CallingConvention.StdCall)]
         internal static extern uint SHAppBarMessage(int dwMessage, ref APPBARDATA pData);
 
@@ -82,5 +98,11 @@ namespace WpfAppBar
         
         [DllImport("dwmapi.dll")]
         internal static extern int DwmSetWindowAttribute(IntPtr hWnd, int attr, ref int attrValue, int attrSize);
+
+        [DllImport("User32.dll")]
+        internal static extern IntPtr MonitorFromWindow(IntPtr hWnd, MonitorDefaultTo dwFlags);
+
+        [DllImport("User32.dll")]
+        internal static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
     }
 }

--- a/WpfAppBar/WpfAppBar.csproj
+++ b/WpfAppBar/WpfAppBar.csproj
@@ -35,8 +35,6 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>

--- a/WpfAppBar/WpfAppBar.csproj
+++ b/WpfAppBar/WpfAppBar.csproj
@@ -35,6 +35,8 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
   </ItemGroup>


### PR DESCRIPTION
This is a rebase of #20, plus two Interop calls to avoid picking up dependencies on `Windows Forms` and `System.Drawing`, which @PhilipRieck expressed an interest in avoiding in #21.

This has been tested with 3 monitors in a non-rectangular composition, in all four directions, including edges with system taskbars on them.

I couldn't reproduce the bug reported by @damonwildercarr in the #20 thread.

Initially I wrote this PR against #21, but I found that because it used screen Bounds instead of Work Area, and dropped the tracking of the DockedSize, it could get stuck in loops when docking against edges that had a system taskbar. This smaller patch seems to be more stable.